### PR TITLE
Add trailing "ends here" line for package.el compatibility

### DIFF
--- a/macro-math.el
+++ b/macro-math.el
@@ -124,3 +124,4 @@ If DIGITS is nil, `macro-math-rounding-precision' will be used."
      (format "%%.%df" digits) number)))
 
 (provide 'macro-math)
+;;; macro-math.el ends here


### PR DESCRIPTION
This minor fix allows `package-install-file` to work correctly.
